### PR TITLE
fix rmt driver install for latest IDF changes

### DIFF
--- a/components/led_strip/led_strip.c
+++ b/components/led_strip/led_strip.c
@@ -238,7 +238,7 @@ static bool led_strip_init_rmt(struct led_strip_t *led_strip)
     if (cfg_ok != ESP_OK) {
         return false;
     }
-    esp_err_t install_ok = rmt_driver_install(rmt_cfg.channel, 0, led_strip->rmt_interrupt_num);
+    esp_err_t install_ok = rmt_driver_install(rmt_cfg.channel, 0, 0);
     if (install_ok != ESP_OK) {
         return false;
     }


### PR DESCRIPTION
latest ESP32 IDF changed the 3rd param internal behavior but the external API/header still show old. 3rd param is now a "flags" variable.

A '0' here now means setup the interrupt/driver to their default values. Apparently the interrupt number is no longer needed.